### PR TITLE
Fixed build error issue when UWP project are created.

### DIFF
--- a/XFPCLApp.UWP/MainPage.xaml.cs
+++ b/XFPCLApp.UWP/MainPage.xaml.cs
@@ -21,7 +21,7 @@ namespace $safeprojectname$
         {
             this.InitializeComponent();
 
-            LoadApplication(new XFPCLApp.App());
+            LoadApplication(new $ext_safeprojectname$.App());
         }
     }
 }


### PR DESCRIPTION
Updated MainPage.xaml.cs to fix the build error by using ```$ext_safeprojectname$```. (Issue #2)